### PR TITLE
Make it fully non-blocking

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "ESP32-RTTTL",
-    "version": "1.3",
+    "version": "1.4",
     "description": "A library that plays RTTTL melodies on an ESP32",
     "keywords": "other, rtttl, melody, esp32, music",
     "repository":

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=ESP32-RTTTL
+version=1.1.0
+author=2ni, Antoine Beauchamp, Ryan Hu
+maintainer=Ryan Hu
+sentence=RTTTL playback on ESP32 using LEDC.
+paragraph=Non-blocking tone generation for ESP32 based on LEDC PWM channels.
+category=Signal Input/Output
+url=https://github.com/2ni/ESP32-RTTTL
+architectures=esp32

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP32-RTTTL
-version=1.1.0
+version=1.4.0
 author=2ni, Antoine Beauchamp, Ryan Hu
 maintainer=Ryan Hu
 sentence=RTTTL playback on ESP32 using LEDC.

--- a/src/RTTTL.cpp
+++ b/src/RTTTL.cpp
@@ -17,7 +17,7 @@ RTTTL::RTTTL(const byte pin) {
   this->pin = pin;
 
   // Attach LEDC channel automatically (Core 3.x doesn't use channel number)
-  ledcAttachPin(pin, 1000, 10);
+  ledcAttach(pin, 1000, 10);
 }
 
 void RTTTL::loadSong(const char *song) {


### PR DESCRIPTION
Keep the same public methods: loadSong(), play(), stop(), isPlaying(), done()

Remove all delay() usage

Make tone() asynchronous (start note, set noteEndTime)

Have play() check millis() to decide when to stop current tone and trigger next

Make it channel-agnostic (no more hardcoded LEDC channel)

Fully compatible with ESP32 Core 3.x (uses ledcAttachPin() and ledcWriteTone())